### PR TITLE
Observer pattern

### DIFF
--- a/lib/src/main/java/edu/touro/mco152/bm/DiskTester.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/DiskTester.java
@@ -2,6 +2,8 @@ package edu.touro.mco152.bm;
 
 import edu.touro.mco152.bm.command.DiskReadCommand;
 import edu.touro.mco152.bm.command.DiskWriteCommand;
+import edu.touro.mco152.bm.persist.TestSaver;
+import edu.touro.mco152.bm.testing.reporting.ReadTestReporter;
 import edu.touro.mco152.bm.ui.Gui;
 
 import javax.swing.*;
@@ -62,14 +64,39 @@ public class DiskTester extends HardwareTester
     {
         if (App.readTest)
         {
-            DiskReadCommand readCommand = new DiskReadCommand(bUI, App.numOfMarks, App.numOfBlocks, App.blockSizeKb, App.blockSequence);
-            invoker.enqueueCommand(readCommand);
+            DiskReadCommand command = new DiskReadCommand(bUI, App.numOfMarks, App.numOfBlocks, App.blockSizeKb, App.blockSequence);
+            registerObservers(command);
+
+            invoker.enqueueCommand(command);
         }
 
         if (App.writeTest)
         {
-            DiskWriteCommand writeCommand = new DiskWriteCommand(bUI, App.numOfMarks, App.numOfBlocks, App.blockSizeKb, App.blockSequence);
-            invoker.enqueueCommand(writeCommand);
+            DiskWriteCommand command = new DiskWriteCommand(bUI, App.numOfMarks, App.numOfBlocks, App.blockSizeKb, App.blockSequence);
+            registerObservers(command);
+
+            invoker.enqueueCommand(command);
         }
+    }
+
+    /**
+     * Registers relevant observers to the nested DiskReadTest within given command
+     * @param command ReadTestCommand that contains the DiskReadTest that observers are being registered to
+     */
+    private void registerObservers(DiskReadCommand command)
+    {
+        command.getReadTest().registerObserver(new TestSaver());
+        command.getReadTest().registerObserver(new ReadTestReporter());
+        command.getReadTest().registerObserver(new Gui());
+    }
+
+    /**
+     * Registers relevant observers to the nested DiskWriteTest within given command
+     * @param command WriteTestCommand that contains the DiskWriteTest that observers are being registered to
+     */
+    private void registerObservers(DiskWriteCommand command)
+    {
+        command.getWriteTest().registerObserver(new TestSaver());
+        command.getWriteTest().registerObserver(new Gui());
     }
 }

--- a/lib/src/main/java/edu/touro/mco152/bm/SlackManager.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/SlackManager.java
@@ -1,0 +1,124 @@
+package edu.touro.mco152.bm;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.api.ApiTestResponse;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+
+import java.io.*;
+import java.util.logging.*;
+
+/**
+ * A Slack Manager for BadBM that just knows how to send a string msg to a pre-designated channel
+ * whose token is in an external file.
+ * Usage:
+ * SlackManager slackmgr = new SlackManager("myAppName");
+ * Boolean worked = slackmgr.postMsg2OurChannel(":smile: Benchmark completed");
+ */
+public class SlackManager {
+    private static Logger log = Logger.getLogger("SlackManager");
+    private static Slack slack = null;  // obtain/keep one copy of expensive item
+
+    /**
+     * The channel we will send all our messages to
+     */
+    private final String ourChannel = "mco152_auto_notifications";
+    private String appName = "App";
+
+    private SlackManager() {
+        // disallow private constructor
+    }
+
+    /**
+     * Construct a Slack Manager for our application, to be used for sending messages to Slack
+     *
+     * @param appName - pass a sring like BadBM, or whatever name you want to appear in msgs
+     */
+    public SlackManager(String appName) {
+        this.appName = appName;
+
+        if (slack == null)
+            slack = Slack.getInstance();
+
+        // auto-validate environment
+        try {
+            ApiTestResponse testResponse = slack.methods().apiTest(r -> r.foo("bar"));
+            if (!testResponse.isOk()) {
+                log.severe("Problem with auto-validation of Slack: "
+                        + testResponse.getError());
+            }
+        } catch (IOException | SlackApiException exc) {
+            log.log(Level.SEVERE, "SlackManager: Problem with auto-validation of Slack", exc);
+        }
+    }
+
+    public static void main(String[] args) {
+        SlackManager slackmgr = new SlackManager("BadBM");
+        // Boolean worked = slackmgr.postMsg2OurChannel(":cry: Benchmark failed");
+        Boolean worked = slackmgr.postMsg2OurChannel(":smile: Benchmark completed");
+        log.info("Retcode from test sending msg is " + worked);
+    }
+
+    /**
+     * Post slack message to our pre-defined channel using predefined credential token
+     *
+     * @param msg - String with message to post, can contain emojis like :smile:
+     * @return True if successful
+     */
+    public Boolean postMsg2OurChannel(String msg) {
+        // Initialize an API Methods client with the given token
+        MethodsClient methods = slack.methods(getSlackToken());
+
+        String postText = String.format("Automated message from <%s>%s: %s",
+                System.getProperty("user.name"), appName, msg);
+
+        // Build a request object
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .channel(ourChannel)
+                .text(postText)
+                .build();
+
+        // Get a response as a Java object
+        ChatPostMessageResponse response = null;
+        try {
+            response = methods.chatPostMessage(request);
+        } catch (IOException | SlackApiException exc) {
+            log.log(Level.SEVERE, "SlackManager: Problem with execution of chatPostMessage", exc);
+            return false;
+        }
+
+
+        if (response.isOk()) {
+            return true;
+        } else {
+            log.severe("SlackManager: Problem with Response = " + response);
+            return false;
+        }
+    }
+
+    /**
+     * Obtain Slack security token for our bot/app/channel from file slacktoken.txt.
+     * Cant be in code in case gets checked in to Github,
+     * which is illegal acc to Slack and will get invalidated when detected.
+     * <p>
+     * If the token is a bot token, it starts with `xoxb-` while if it's a user token, it starts with `xoxp-`
+     */
+    private String getSlackToken() {
+        String token = "Unknown Slack Token";
+        String tfname = System.getenv("TEMP") + File.separator + "slacktoken.txt";
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(tfname));
+            token = br.readLine();
+        } catch (FileNotFoundException e) {
+            log.severe("Could not find token file: " + tfname);
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "Error while read token", e);
+        }
+
+        return token;   // may be actual token or dummy string
+    }
+
+}
+

--- a/lib/src/main/java/edu/touro/mco152/bm/observe/Observable.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/observe/Observable.java
@@ -1,0 +1,23 @@
+package edu.touro.mco152.bm.observe;
+
+/**
+ * All classes that are to be observed by concrete observers should implement this interface. This interface contracts
+ * classes to contain these methods so clients can register, unregister, and notify observers for the implemented class.
+ */
+public interface Observable
+{
+    /**
+     * @param observer observer to register to the observable
+     */
+    void registerObserver(Observer observer);
+
+    /**
+     * @param observer observer to unregister from the observable
+     */
+    void unregisterObserver(Observer observer);
+
+    /**
+     * Notifies registered observers of this subjects completion
+     */
+    void notifyObservers();
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/observe/Observer.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/observe/Observer.java
@@ -1,0 +1,18 @@
+package edu.touro.mco152.bm.observe;
+
+/**
+ * An concrete observer is a class that needs to observe a subject in order to know when to perform a task. Classes that
+ * require this behavior should implement this interface.
+ */
+public interface Observer
+{
+    /**
+     * Lets this object know that its observable has completed it's task and executes subsequent logic.
+     */
+    void update();
+
+    /**
+     * Lets this object know that its observable has completed it's task and executes subsequent logic.
+     */
+    void update(Object o);
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/observe/Observer.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/observe/Observer.java
@@ -13,6 +13,7 @@ public interface Observer
 
     /**
      * Lets this object know that its observable has completed it's task and executes subsequent logic.
+     * @param o The object necessary for the implementing class to execute properly.
      */
     void update(Object o);
 }

--- a/lib/src/main/java/edu/touro/mco152/bm/persist/TestSaver.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/persist/TestSaver.java
@@ -1,0 +1,35 @@
+package edu.touro.mco152.bm.persist;
+
+import edu.touro.mco152.bm.observe.Observer;
+import jakarta.persistence.EntityManager;
+
+/**
+ * An Observer implementation that, when notified, saves tests (benchmarks) into the system's database
+ */
+public class TestSaver implements Observer
+{
+    private final EntityManager em = EM.getEntityManager();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update()
+    {
+
+    }
+
+    /**
+     * {@inheritDoc} The logic in this context is uploading the benchmarks DiskRun to the system's database.
+     */
+    @Override
+    public void update(Object o)
+    {
+        if (o instanceof DiskRun)
+        {
+            em.getTransaction().begin();
+            em.persist(o);
+            em.getTransaction().commit();
+        }
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/DiskReadTest.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/DiskReadTest.java
@@ -4,6 +4,8 @@ import edu.touro.mco152.bm.App;
 import edu.touro.mco152.bm.BenchmarkUI;
 import edu.touro.mco152.bm.DiskMark;
 import edu.touro.mco152.bm.Util;
+import edu.touro.mco152.bm.observe.Observable;
+import edu.touro.mco152.bm.observe.Observer;
 import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 
@@ -11,6 +13,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,8 +27,10 @@ import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
  * <p>
  * This is a concrete DiskTest class. It's job is to perform Read Tests for Disks
  */
-public class DiskReadTest extends DiskTest
+public class DiskReadTest extends DiskTest implements Observable
 {
+    private final Set<Observer> observers = new HashSet<>();
+
     private int rUnitsComplete;
     private int rUnitsTotal;
     private int startFileNum;
@@ -175,6 +181,36 @@ public class DiskReadTest extends DiskTest
     public DiskRun getRun()
     {
         return run;
+    }
+
+    /**
+     * @param observer observer to register to the observable
+     */
+    @Override
+    public void registerObserver(Observer observer)
+    {
+        observers.add(observer);
+    }
+
+    /**
+     * @param observer observer to unregister from the observable
+     */
+    @Override
+    public void unregisterObserver(Observer observer)
+    {
+        observers.remove(observer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyObservers()
+    {
+        for (Observer observer : observers)
+        {
+            observer.update(run);
+        }
     }
 }
 

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/DiskReadTest.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/DiskReadTest.java
@@ -117,6 +117,7 @@ public class DiskReadTest extends DiskTest implements Observable
             bUI.stageData(rMark);
             trackRunStats(run);
         }
+        notifyObservers();
     }
 
     /**

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/DiskWriteTest.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/DiskWriteTest.java
@@ -125,6 +125,7 @@ public class DiskWriteTest extends DiskTest implements Observable
             bUI.stageData(wMark);
             trackRunStats(run);
         }
+        notifyObservers();
     }
 
     /**
@@ -190,7 +191,7 @@ public class DiskWriteTest extends DiskTest implements Observable
     {
         return run;
     }
-    
+
     /**
      * @param observer observer to register to the observable
      */

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/DiskWriteTest.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/DiskWriteTest.java
@@ -4,6 +4,8 @@ import edu.touro.mco152.bm.App;
 import edu.touro.mco152.bm.BenchmarkUI;
 import edu.touro.mco152.bm.DiskMark;
 import edu.touro.mco152.bm.Util;
+import edu.touro.mco152.bm.observe.Observable;
+import edu.touro.mco152.bm.observe.Observer;
 import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 
@@ -11,6 +13,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,8 +27,10 @@ import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
  * <p>
  * This is a concrete DiskTest class. It's job is to perform Write Tests for Disks
  */
-public class DiskWriteTest extends DiskTest
+public class DiskWriteTest extends DiskTest implements Observable
 {
+    private final Set<Observer> observers = new HashSet<>();
+
     private int wUnitsComplete;
     private int wUnitsTotal;
     private int startFileNum;
@@ -183,5 +189,35 @@ public class DiskWriteTest extends DiskTest
     public DiskRun getRun()
     {
         return run;
+    }
+    
+    /**
+     * @param observer observer to register to the observable
+     */
+    @Override
+    public void registerObserver(Observer observer)
+    {
+        observers.add(observer);
+    }
+
+    /**
+     * @param observer observer to unregister from the observable
+     */
+    @Override
+    public void unregisterObserver(Observer observer)
+    {
+        observers.remove(observer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyObservers()
+    {
+        for (Observer observer : observers)
+        {
+            observer.update(run);
+        }
     }
 }

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/ReadTestReporter.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/ReadTestReporter.java
@@ -1,0 +1,53 @@
+package edu.touro.mco152.bm.testing.reporting;
+import edu.touro.mco152.bm.observe.Observer;
+import edu.touro.mco152.bm.persist.DiskRun;
+
+/**
+ * An Observer that reports on ReadTests, alarming the project manager if the report does not meat company standards.
+ */
+public class ReadTestReporter extends TestReporter implements Observer
+{
+    @Override
+    public void update()
+    {
+
+    }
+
+    /**
+     * Asserts the DiskRun is up to standards via {@link #assertBenchmarkResults(DiskRun)}. If the DiskRun shows unimpressive
+     * results, the method will update the product manager via slack.
+     * @param o DiskRun from the DiskReadTest
+     */
+    @Override
+    public void update(Object o)
+    {
+        if (o instanceof DiskRun)
+        {
+            if (assertBenchmarkResults((DiskRun)o))
+                slackManager.postMsg2OurChannel("Test Report - read benchmark completed with iteration max time " +
+                        decimalFormatter.format(calculateIterationMaxTimePercent((DiskRun)o)) + "% greater than benchmarks average iteration time" +
+                        " when only a 3% difference is allowed.");
+        }
+    }
+
+    /**
+     * Asserts 'rules' to be followed by the DiskRun.
+     * @param run DiskRun for the method to enforce rules over
+     * @return true if the DiskRun shows unimpressive results
+     */
+    @Override
+    protected boolean assertBenchmarkResults(DiskRun run)
+    {
+        return calculateIterationMaxTimePercent(run) > 3;
+    }
+
+    /**
+     * @param run DiskRun that contains the relevant information
+     * @return the percentage difference between the max iteration time vs. the average iteration time
+     */
+    private double calculateIterationMaxTimePercent(DiskRun run)
+    {
+        return 100 - ((run.getRunAvg() / run.getRunMax()) * 100);
+    }
+}
+

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/TestReporter.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/TestReporter.java
@@ -1,0 +1,26 @@
+package edu.touro.mco152.bm.testing.reporting;
+
+import edu.touro.mco152.bm.SlackManager;
+import edu.touro.mco152.bm.observe.Observer;
+import edu.touro.mco152.bm.persist.DiskRun;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * A base class for Reporter Observer classes to implement. It enforces all sub-classes to implement the
+ * {@link #assertBenchmarkResults(DiskRun)} which enforces 'rules' for benchmarks.
+ */
+public abstract class TestReporter implements Observer
+{
+    protected final SlackManager slackManager = new SlackManager("GoodBM");
+    protected final NumberFormat decimalFormatter = new DecimalFormat("#0.00");
+
+    /**
+     * Ensures that a DiskRun from a test (benchmark) is stable by enforcing conditions the run must pass.
+     * @param run DiskRun for the method to enforce rules over
+     * @return true if the DiskRun abides to all enforced rules, false otherwise
+     */
+    protected abstract boolean assertBenchmarkResults(DiskRun run);
+}
+

--- a/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/WriteTestReporter.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/testing/reporting/WriteTestReporter.java
@@ -1,0 +1,31 @@
+package edu.touro.mco152.bm.testing.reporting;
+
+import edu.touro.mco152.bm.observe.Observer;
+import edu.touro.mco152.bm.persist.DiskRun;
+
+/**
+ * This class is currently not in use but can be implemented later if necessary.
+ * An Observer that reports on WriteTests, alarming the project manager if the report does not meat company standards.
+ */
+public class WriteTestReporter extends TestReporter implements Observer
+{
+
+    @Override
+    public void update()
+    {
+        //TODO Implement when necessary
+    }
+
+    @Override
+    public void update(Object o)
+    {
+        //TODO Implement when necessary
+    }
+
+    @Override
+    protected boolean assertBenchmarkResults(DiskRun run)
+    {
+        return false; //TODO Implement when necessary
+    }
+}
+

--- a/lib/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -19,7 +19,8 @@ import java.io.Serial;
 import java.text.NumberFormat;
 
 /**
- * Store gui references for easy access
+ * Store gui references for easy access. It now implements the Observer interface. As such, when notified, it will
+ *  * add a DiskRun to the GUI's runPanel.
  */
 public final class Gui implements Observer
 {

--- a/lib/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -2,6 +2,8 @@ package edu.touro.mco152.bm.ui;
 
 import edu.touro.mco152.bm.App;
 import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.observe.Observer;
+import edu.touro.mco152.bm.persist.DiskRun;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
@@ -19,8 +21,8 @@ import java.text.NumberFormat;
 /**
  * Store gui references for easy access
  */
-public final class Gui {
-
+public final class Gui implements Observer
+{
     public static ChartPanel chartPanel = null;
     public static MainFrame mainFrame = null;
     public static SelectFrame selFrame = null;
@@ -138,5 +140,30 @@ public final class Gui {
         chart.getXYPlot().getRenderer().setSeriesVisibleInLegend(5, App.readTest);
         chart.getXYPlot().getRenderer().setSeriesVisibleInLegend(6, App.readTest && App.showMaxMin);
         chart.getXYPlot().getRenderer().setSeriesVisibleInLegend(7, App.readTest && App.showMaxMin);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     *This method is not used in this implementation
+     */
+    @Override
+    public void update()
+    {
+
+    }
+
+    /**
+     * Lets this object know that its observable has completed it's task and executes subsequent logic.
+     * @param o The object necessary for the implementing class to execute properly. In this case, a DiskRun Object
+     *          reflecting a DiskReadTest's or DiskWriteTest's performance.
+     */
+    @Override
+    public void update(Object o)
+    {
+        if (o instanceof DiskRun)
+        {
+            Gui.runPanel.addRun((DiskRun) o);
+        }
     }
 }


### PR DESCRIPTION
## Packages / Contained Classes / Class Functions
1. observe
     - `Observer` - an interface for observers of the observer pattern to implement
     - `Observable` - an interface for observerables of the observer pattern to implement
2. reporting
     - `TestReporter` - abstract base class for ReadTestReporter and WriteTestReporter
     - `ReadTestReporter` - an observer implementation. Sends slack messages in case of poor disk performance
     - `WriteTestReporter` - an observer implementation. Currently not implemented (added for future potential use)
3. persist
     - `TestSaver` - an observer implementation. Saves benchmarks and uploads them to database.

 
### General Classes / Class Changes
1. `SlackManager` - handles all slack related tasks
2. `Gui` - added observer implementation. Now is solely responsible for adding runs to the Gui.